### PR TITLE
Add RandomColors plugin

### DIFF
--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -4,3 +4,5 @@ endif()
 if(ENABLE_PLUGIN_QUICKCOMMANDS)
     add_subdirectory(QuickCommands)
 endif()
+
+add_subdirectory(RandomColors)

--- a/src/plugins/RandomColors/CMakeLists.txt
+++ b/src/plugins/RandomColors/CMakeLists.txt
@@ -1,0 +1,13 @@
+kcoreaddons_add_plugin(konsole_randomcolorsplugin
+    SOURCES
+        randomcolorsplugin.cpp
+    INSTALL_NAMESPACE
+        "konsoleplugins"
+)
+
+configure_file(konsole_randomcolors.in.json konsole_randomcolors.json)
+
+target_link_libraries(konsole_randomcolorsplugin
+    konsoleprivate
+    konsoleapp
+)

--- a/src/plugins/RandomColors/konsole_randomcolors.in.json
+++ b/src/plugins/RandomColors/konsole_randomcolors.in.json
@@ -1,0 +1,8 @@
+{
+    "KPlugin": {
+        "Name": "Random Colors",
+        "Name[de]": "Zufällige Farben",
+        "Name[x-test]": "xxRandom Colorsxx",
+        "Version": "@RELEASE_SERVICE_VERSION@"
+    }
+}

--- a/src/plugins/RandomColors/randomcolorsplugin.cpp
+++ b/src/plugins/RandomColors/randomcolorsplugin.cpp
@@ -1,0 +1,53 @@
+// This file was part of the KDE libraries
+// SPDX-FileCopyrightText: 2024 Your Name <your.email@example.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "randomcolorsplugin.h"
+
+#include "session/SessionController.h"
+#include "session/SessionManager.h"
+#include "profile/Profile.h"
+#include "colorscheme/ColorSchemeManager.h"
+
+#include <QRandomGenerator>
+
+#include "MainWindow.h"
+
+K_PLUGIN_CLASS_WITH_JSON(RandomColorsPlugin, "konsole_randomcolors.json")
+
+RandomColorsPlugin::RandomColorsPlugin(QObject *parent, const QVariantList &args)
+    : Konsole::IKonsolePlugin(parent, args)
+{
+    setName(QStringLiteral("RandomColors"));
+}
+
+RandomColorsPlugin::~RandomColorsPlugin() = default;
+
+void RandomColorsPlugin::activeViewChanged(Konsole::SessionController *controller, Konsole::MainWindow *mainWindow)
+{
+    Q_UNUSED(mainWindow)
+    if (!controller) {
+        return;
+    }
+
+    auto schemes = Konsole::ColorSchemeManager::instance()->allColorSchemes();
+    if (schemes.isEmpty()) {
+        return;
+    }
+
+    int index = QRandomGenerator::global()->bounded(schemes.size());
+    const auto scheme = schemes.at(index);
+    if (!scheme) {
+        return;
+    }
+
+    auto profile = Konsole::SessionManager::instance()->sessionProfile(controller->session());
+    profile = Konsole::Profile::Ptr(new Konsole::Profile(profile));
+    profile->setProperty(Konsole::Profile::ColorScheme, scheme->name());
+
+    controller->view()->applyProfile(profile);
+    Konsole::SessionManager::instance()->setSessionProfile(controller->session(), profile);
+}
+
+#include "moc_randomcolorsplugin.cpp"
+#include "randomcolorsplugin.moc"

--- a/src/plugins/RandomColors/randomcolorsplugin.h
+++ b/src/plugins/RandomColors/randomcolorsplugin.h
@@ -1,0 +1,26 @@
+// This file was part of the KDE libraries
+// SPDX-FileCopyrightText: 2024 Your Name <your.email@example.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef RANDOMCOLORSPLUGIN_H
+#define RANDOMCOLORSPLUGIN_H
+
+#include <pluginsystem/IKonsolePlugin.h>
+
+namespace Konsole {
+class SessionController;
+class MainWindow;
+}
+
+class RandomColorsPlugin : public Konsole::IKonsolePlugin
+{
+    Q_OBJECT
+
+public:
+    RandomColorsPlugin(QObject *parent, const QVariantList &args);
+    ~RandomColorsPlugin() override;
+
+    void activeViewChanged(Konsole::SessionController *controller, Konsole::MainWindow *mainWindow) override;
+};
+
+#endif // RANDOMCOLORSPLUGIN_H


### PR DESCRIPTION
## Summary
- introduce RandomColors plugin that applies a random color scheme whenever the active view changes
- hook plugin into build system and provide plugin metadata

## Testing
- `cmake -S . -B build` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0".)*


------
https://chatgpt.com/codex/tasks/task_e_68b994987f348329869e114171cb240f