### PR TITLE
Allow building with Qt 6.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(RELEASE_SERVICE_VERSION "${RELEASE_SERVICE_VERSION_MAJOR}.${RELEASE_SERVICE_
 # See comments in https://invent.kde.org/utilities/konsole/-/commit/9d8e47298c81fc1e47c998eda1b6e980589274eb
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-set(QT_MIN_VERSION "6.5.0")
+set(QT_MIN_VERSION "6.4.2")
 set(KF6_DEP_VERSION "6.0.0")
 
 # Release script will create bugzilla versions

--- a/src/tests/demo_konsolepart/CMakeLists.txt
+++ b/src/tests/demo_konsolepart/CMakeLists.txt
@@ -12,7 +12,7 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 include(ECMInstallIcons)
 include(FeatureSummary)
 
-set(QT_MIN_VERSION "6.5.0")
+set(QT_MIN_VERSION "6.4.2")
 find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets)
 
 set(REQUIRED_KF_VERSION "6.0.0")


### PR DESCRIPTION
## Summary
- lower `QT_MIN_VERSION` to 6.4.2 in main and demo CMake files

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ECM" (requested version 6.0.0))*

------
https://chatgpt.com/codex/tasks/task_e_68b9977e158c832991c81e8422f1f0a8