### PR TITLE
Add createWidgetsForMainWindow stub for RandomColors plugin

### DIFF
--- a/src/plugins/RandomColors/randomcolorsplugin.cpp
+++ b/src/plugins/RandomColors/randomcolorsplugin.cpp
@@ -23,6 +23,11 @@ RandomColorsPlugin::RandomColorsPlugin(QObject *parent, const QVariantList &args
 
 RandomColorsPlugin::~RandomColorsPlugin() = default;
 
+void RandomColorsPlugin::createWidgetsForMainWindow(Konsole::MainWindow *mainWindow)
+{
+    Q_UNUSED(mainWindow);
+}
+
 void RandomColorsPlugin::activeViewChanged(Konsole::SessionController *controller, Konsole::MainWindow *mainWindow)
 {
     Q_UNUSED(mainWindow)

--- a/src/plugins/RandomColors/randomcolorsplugin.h
+++ b/src/plugins/RandomColors/randomcolorsplugin.h
@@ -20,6 +20,7 @@ public:
     RandomColorsPlugin(QObject *parent, const QVariantList &args);
     ~RandomColorsPlugin() override;
 
+    void createWidgetsForMainWindow(Konsole::MainWindow *mainWindow) override;
     void activeViewChanged(Konsole::SessionController *controller, Konsole::MainWindow *mainWindow) override;
 };
 


### PR DESCRIPTION
## Summary
- override `createWidgetsForMainWindow` in RandomColors plugin header
- provide minimal no-op implementation

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ECM")*


------
https://chatgpt.com/codex/tasks/task_e_68b9d7cb6a80832982ad0c23997befef