### PR TITLE
Add plugin toggle and metadata for Random Colors

### DIFF
--- a/src/plugins/RandomColors/konsole_randomcolors.in.json
+++ b/src/plugins/RandomColors/konsole_randomcolors.in.json
@@ -3,6 +3,8 @@
         "Name": "Random Colors",
         "Name[de]": "Zufällige Farben",
         "Name[x-test]": "xxRandom Colorsxx",
+        "Description": "Assigns a random color scheme whenever the active view changes",
+        "Description[de]": "Weist bei jedem Fensterwechsel ein zufälliges Farbschema zu",
         "Version": "@RELEASE_SERVICE_VERSION@"
     }
 }

--- a/src/plugins/RandomColors/randomcolorsplugin.cpp
+++ b/src/plugins/RandomColors/randomcolorsplugin.cpp
@@ -9,6 +9,8 @@
 #include "profile/Profile.h"
 #include "colorscheme/ColorSchemeManager.h"
 
+#include <KLocalizedString>
+#include <QAction>
 #include <QRandomGenerator>
 
 #include "MainWindow.h"
@@ -25,13 +27,20 @@ RandomColorsPlugin::~RandomColorsPlugin() = default;
 
 void RandomColorsPlugin::createWidgetsForMainWindow(Konsole::MainWindow *mainWindow)
 {
-    Q_UNUSED(mainWindow);
+    auto action = new QAction(i18n("Enable Random Colors"), mainWindow);
+    action->setCheckable(true);
+    action->setChecked(true);
+    m_enableActions.insert(mainWindow, action);
 }
 
 void RandomColorsPlugin::activeViewChanged(Konsole::SessionController *controller, Konsole::MainWindow *mainWindow)
 {
-    Q_UNUSED(mainWindow)
     if (!controller) {
+        return;
+    }
+
+    auto action = m_enableActions.value(mainWindow, nullptr);
+    if (action && !action->isChecked()) {
         return;
     }
 
@@ -52,6 +61,11 @@ void RandomColorsPlugin::activeViewChanged(Konsole::SessionController *controlle
 
     controller->view()->applyProfile(profile);
     Konsole::SessionManager::instance()->setSessionProfile(controller->session(), profile);
+}
+
+QList<QAction *> RandomColorsPlugin::menuBarActions(Konsole::MainWindow *mainWindow) const
+{
+    return {m_enableActions.value(mainWindow)};
 }
 
 #include "moc_randomcolorsplugin.cpp"

--- a/src/plugins/RandomColors/randomcolorsplugin.h
+++ b/src/plugins/RandomColors/randomcolorsplugin.h
@@ -7,6 +7,10 @@
 
 #include <pluginsystem/IKonsolePlugin.h>
 
+#include <QHash>
+
+class QAction;
+
 namespace Konsole {
 class SessionController;
 class MainWindow;
@@ -22,6 +26,10 @@ public:
 
     void createWidgetsForMainWindow(Konsole::MainWindow *mainWindow) override;
     void activeViewChanged(Konsole::SessionController *controller, Konsole::MainWindow *mainWindow) override;
+    QList<QAction *> menuBarActions(Konsole::MainWindow *mainWindow) const override;
+
+private:
+    mutable QHash<Konsole::MainWindow *, QAction *> m_enableActions;
 };
 
 #endif // RANDOMCOLORSPLUGIN_H


### PR DESCRIPTION
## Summary
- add toggleable menu action for Random Colors plugin
- document plugin with description metadata

## Testing
- `cmake -S . -B build` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0".)*


------
https://chatgpt.com/codex/tasks/task_e_68b9db60fd60832987ce766181d19e6f