### PR TITLE
RandomColors: add SPDX copyright info

### DIFF
--- a/src/plugins/RandomColors/randomcolorsplugin.cpp
+++ b/src/plugins/RandomColors/randomcolorsplugin.cpp
@@ -1,5 +1,5 @@
 // This file was part of the KDE libraries
-// SPDX-FileCopyrightText: 2024 Your Name <your.email@example.com>
+// SPDX-FileCopyrightText: 2024 bunthut <43689017+bunthut@users.noreply.github.com>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "randomcolorsplugin.h"

--- a/src/plugins/RandomColors/randomcolorsplugin.h
+++ b/src/plugins/RandomColors/randomcolorsplugin.h
@@ -1,5 +1,5 @@
 // This file was part of the KDE libraries
-// SPDX-FileCopyrightText: 2024 Your Name <your.email@example.com>
+// SPDX-FileCopyrightText: 2024 bunthut <43689017+bunthut@users.noreply.github.com>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef RANDOMCOLORSPLUGIN_H


### PR DESCRIPTION
## Summary
- credit the Random Colors plugin to bunthut

## Testing
- `ctest` *(fails: No test configuration file found)*
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ECM")*
- `reuse lint` *(fails: project is not compliant with REUSE 3.3 specification)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e7d3c08c8329abf279df82be38ed