### PR TITLE
Set translation domain for RandomColors plugin

### DIFF
--- a/src/plugins/RandomColors/randomcolorsplugin.cpp
+++ b/src/plugins/RandomColors/randomcolorsplugin.cpp
@@ -20,6 +20,7 @@ K_PLUGIN_CLASS_WITH_JSON(RandomColorsPlugin, "konsole_randomcolors.json")
 RandomColorsPlugin::RandomColorsPlugin(QObject *parent, const QVariantList &args)
     : Konsole::IKonsolePlugin(parent, args)
 {
+    KLocalizedString::setApplicationDomain("konsole");
     setName(QStringLiteral("RandomColors"));
 }
 


### PR DESCRIPTION
## Summary
- initialize translation domain for RandomColors plugin

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ECM" (requested version 6.0.0))*

------
https://chatgpt.com/codex/tasks/task_e_68b9e7d55ec483298130e351cd22cfc5