### PR TITLE
Fix plugin version parsing for plugin compatibility check

### DIFF
--- a/src/pluginsystem/PluginManager.cpp
+++ b/src/pluginsystem/PluginManager.cpp
@@ -34,7 +34,7 @@ PluginManager::~PluginManager() = default;
 void PluginManager::loadAllPlugins()
 {
     QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(QStringLiteral("konsoleplugins"), [](const KPluginMetaData &data) {
-        const QVersionNumber pluginVersion = QVersionNumber::fromString(QString::fromLatin1(data.version()));
+        const QVersionNumber pluginVersion = QVersionNumber::fromString(data.version());
         const QVersionNumber releaseVersion = QVersionNumber::fromString(QLatin1String(RELEASE_SERVICE_VERSION));
         if (pluginVersion.majorVersion() == releaseVersion.majorVersion() && pluginVersion.minorVersion() == releaseVersion.minorVersion()) {
             return true;


### PR DESCRIPTION
## Summary
- simplify plugin version parsing by passing QString directly to QVersionNumber

## Testing
- `cmake ..` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0")*


------
https://chatgpt.com/codex/tasks/task_e_68b9f58ae590832985e32139c4eedf4e