### PR TITLE
Remove unused KCMUtils dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ find_package(KF6 ${KF6_DEP_VERSION} REQUIRED
     NewStuff
     Notifications
     NotifyConfig
-    KCMUtils
     Parts
     Service
     TextWidgets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,7 +342,6 @@ target_link_libraries(konsoleapp
   KF6::NotifyConfig
   KF6::Crash
   KF6::ConfigWidgets
-  KF6::KCMUtilsWidgets
 )
 
 set_target_properties(konsoleapp PROPERTIES


### PR DESCRIPTION
## Summary
- drop KF6::KCMUtilsWidgets from konsoleapp link
- stop requiring KCMUtils in top-level CMake

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ECM" (requested version 6.0.0))*

------
https://chatgpt.com/codex/tasks/task_e_68b9f693326c83299ece7838734b7e68