### PR TITLE
Add KCMUtils dependency for Konsole

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ find_package(KF6 ${KF6_DEP_VERSION} REQUIRED
     GuiAddons
     I18n
     IconThemes
+    KCMUtils
     KIO
     NewStuff
     Notifications

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ set(konsole_LIBS
     KF6::TextWidgets
     KF6::GuiAddons
     KF6::IconThemes
+    KF6::KCMUtils
     KF6::Bookmarks
     KF6::I18n
     KF6::KIOWidgets


### PR DESCRIPTION
## Summary
- Extend KF6 dependency list to include KCMUtils
- Link against KF6::KCMUtils for konsole

## Testing
- `cmake -S . -B build` *(fails: Could not find ECM version 6.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f86afcb0832999dea2809a960670