### PR TITLE
Fix PluginSettings for KF6 KPluginWidget API

### DIFF
--- a/src/settings/PluginSettings.cpp
+++ b/src/settings/PluginSettings.cpp
@@ -15,6 +15,7 @@
 #include <KPluginMetaData>
 #include <KPluginWidget>
 #include <KSharedConfig>
+#include <KConfigGroup>
 #include <keditlistwidget.h>
 
 using namespace Konsole;
@@ -25,9 +26,11 @@ PluginSettings::PluginSettings(QWidget *parent)
     setupUi(this);
 
     // Populate plugin list
-    pluginWidget->setConfig(KSharedConfig::openConfig());
+    auto config = KSharedConfig::openConfig();
+    pluginWidget->setConfig(config->group(QStringLiteral("Plugins")));
     const auto metaData = KPluginMetaData::findPlugins(QStringLiteral("konsoleplugins"));
-    pluginWidget->addPlugins(metaData, KPluginWidget::ReadConfigFile);
+    pluginWidget->addPlugins(metaData, QString());
+    pluginWidget->load();
 
     // Use a file dialog to add directories
     connect(addPathButton, &QPushButton::clicked, this, [this]() {


### PR DESCRIPTION
## Summary
- Adjust PluginSettings to use KConfigGroup with KPluginWidget
- Replace deprecated addPlugins usage and load plugin configuration

## Testing
- `pre-commit run --files src/settings/PluginSettings.cpp` *(failed: command not found)*
- `cmake -B build -S .` *(failed: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0"; installed version 5.115.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fd5f21308329b1f5ef92c04fc85c