### PR TITLE
Fix PluginManager loadAllPlugins syntax

### DIFF
--- a/src/pluginsystem/PluginManager.cpp
+++ b/src/pluginsystem/PluginManager.cpp
@@ -33,24 +33,22 @@ PluginManager::PluginManager()
 PluginManager::~PluginManager() = default;
 
 void PluginManager::loadAllPlugins()
-QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(QStringLiteral("konsoleplugins"), [](const KPluginMetaData &data) {
-    const QVersionNumber pluginVersion = QVersionNumber::fromString(QString::fromLatin1(data.version())); // Ensure proper conversion
-    const QVersionNumber releaseVersion = QVersionNumber::fromString(QLatin1String(RELEASE_SERVICE_VERSION));
-    
-    // Check if the major and minor versions match
-    if (pluginVersion.majorVersion() == releaseVersion.majorVersion() && 
-        pluginVersion.minorVersion() == releaseVersion.minorVersion()) {
-        return true;
-    } else {
+{
+    auto filter = [](const KPluginMetaData &data) {
+        const QVersionNumber pluginVersion = QVersionNumber::fromString(QString::fromLatin1(data.version()));
+        const QVersionNumber releaseVersion = QVersionNumber::fromString(QLatin1String(RELEASE_SERVICE_VERSION));
+
+        // Accept only plugins that match the current major and minor release version
+        if (pluginVersion.majorVersion() == releaseVersion.majorVersion() &&
+            pluginVersion.minorVersion() == releaseVersion.minorVersion()) {
+            return true;
+        }
+
         qCWarning(KonsoleDebug) << "Ignoring" << data.name() << "plugin version (" << pluginVersion.toString()
                                 << ") doesn't match release version (" << releaseVersion.toString() << ")";
-        return false; // Explicitly return false for clarity
-    }
-});
-
-            return false;
-        }
+        return false;
     };
+
     QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(QStringLiteral("konsoleplugins"), filter);
 
     const QStringList extraPaths = KonsoleSettings::customPluginPaths();


### PR DESCRIPTION
## Summary
- repair PluginManager::loadAllPlugins to properly filter compatible plugins and load extras

## Testing
- `cmake --preset dev` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0")*

------
https://chatgpt.com/codex/tasks/task_e_68ba025ea4308329950dd562f36f2316