### PR TITLE
Fix PluginManager loadAllPlugins API usage

### DIFF
--- a/src/pluginsystem/PluginManager.cpp
+++ b/src/pluginsystem/PluginManager.cpp
@@ -15,6 +15,8 @@
 #include <KLocalizedString>
 #include <KPluginFactory>
 #include <KPluginMetaData>
+#include <KConfigGroup>
+#include <KSharedConfig>
 
 #include <QAction>
 #include <QVersionNumber>
@@ -33,24 +35,22 @@ PluginManager::PluginManager()
 PluginManager::~PluginManager() = default;
 
 void PluginManager::loadAllPlugins()
-QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(QStringLiteral("konsoleplugins"), [](const KPluginMetaData &data) {
-    const QVersionNumber pluginVersion = QVersionNumber::fromString(QString::fromLatin1(data.version())); // Ensure proper conversion
-    const QVersionNumber releaseVersion = QVersionNumber::fromString(QLatin1String(RELEASE_SERVICE_VERSION));
-    
-    // Check if the major and minor versions match
-    if (pluginVersion.majorVersion() == releaseVersion.majorVersion() && 
-        pluginVersion.minorVersion() == releaseVersion.minorVersion()) {
-        return true;
-    } else {
+{
+    auto filter = [](const KPluginMetaData &data) {
+        const QVersionNumber pluginVersion = QVersionNumber::fromString(data.version());
+        const QVersionNumber releaseVersion = QVersionNumber::fromString(QLatin1String(RELEASE_SERVICE_VERSION));
+
+        // Accept only plugins that match the current major and minor release version
+        if (pluginVersion.majorVersion() == releaseVersion.majorVersion() &&
+            pluginVersion.minorVersion() == releaseVersion.minorVersion()) {
+            return true;
+        }
+
         qCWarning(KonsoleDebug) << "Ignoring" << data.name() << "plugin version (" << pluginVersion.toString()
                                 << ") doesn't match release version (" << releaseVersion.toString() << ")";
-        return false; // Explicitly return false for clarity
-    }
-});
-
-            return false;
-        }
+        return false;
     };
+
     QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(QStringLiteral("konsoleplugins"), filter);
 
     const QStringList extraPaths = KonsoleSettings::customPluginPaths();
@@ -58,8 +58,9 @@ QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(QStringLi
         pluginMetaData += KPluginMetaData::findPlugins(path, filter);
     }
 
+    KConfigGroup pluginsConfig(KSharedConfig::openConfig(), QStringLiteral("Plugins"));
     for (const auto &metaData : std::as_const(pluginMetaData)) {
-        if (!metaData.isEnabled()) {
+        if (!metaData.isEnabled(pluginsConfig)) {
             continue;
         }
         const KPluginFactory::Result result = KPluginFactory::instantiatePlugin<IKonsolePlugin>(metaData);


### PR DESCRIPTION
## Summary
- parse plugin versions without redundant QString conversion
- check plugin enabled state via "Plugins" KConfigGroup

## Testing
- `cmake --preset dev` *(fails: Could not find a package configuration file provided by "ECM" (requested version 6.0.0))*

------
https://chatgpt.com/codex/tasks/task_e_68ba025ea4308329950dd562f36f2316