### PR TITLE
Fix plugin version string conversion

### DIFF
--- a/src/pluginsystem/PluginManager.cpp
+++ b/src/pluginsystem/PluginManager.cpp
@@ -37,7 +37,7 @@ PluginManager::~PluginManager() = default;
 void PluginManager::loadAllPlugins()
 {
     auto filter = [](const KPluginMetaData &data) {
-const QVersionNumber pluginVersion = QVersionNumber::fromString(QString::fromLatin1(data.version()));
+        const QVersionNumber pluginVersion = QVersionNumber::fromString(data.version());
 
         const QVersionNumber releaseVersion = QVersionNumber::fromString(QLatin1String(RELEASE_SERVICE_VERSION));
 


### PR DESCRIPTION
## Summary
- remove unnecessary QString::fromLatin1 when parsing plugin version

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ECM")*


------
https://chatgpt.com/codex/tasks/task_e_68ba04f98178832987ab0259b55540af