### PR TITLE
Use Qt version in plugin install path

### DIFF
--- a/src/plugins/QuickCommands/CMakeLists.txt
+++ b/src/plugins/QuickCommands/CMakeLists.txt
@@ -9,7 +9,7 @@ SOURCES
     filtermodel.cpp
     ${EXTRA_QUICKCOMMANDSPLUGIN_SRCS}
 INSTALL_NAMESPACE
-    "konsoleplugins"
+    "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
 )
 
 configure_file(konsole_quickcommands.in.json konsole_quickcommands.json)

--- a/src/plugins/RandomColors/CMakeLists.txt
+++ b/src/plugins/RandomColors/CMakeLists.txt
@@ -2,7 +2,7 @@ kcoreaddons_add_plugin(konsole_randomcolorsplugin
     SOURCES
         randomcolorsplugin.cpp
     INSTALL_NAMESPACE
-        "konsoleplugins"
+        "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
 )
 
 configure_file(konsole_randomcolors.in.json konsole_randomcolors.json)

--- a/src/plugins/SSHManager/CMakeLists.txt
+++ b/src/plugins/SSHManager/CMakeLists.txt
@@ -20,7 +20,7 @@ SOURCES
     sshtreeview.cpp
     ${extra_sshplugin_SRCS}
 INSTALL_NAMESPACE
-    "konsoleplugins"
+    "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
 )
 
 configure_file(konsole_sshmanager.in.json konsole_sshmanager.json)


### PR DESCRIPTION
## Summary
- install plugins under qt versioned namespace to differentiate Qt5 vs Qt6 builds

## Testing
- `cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$(pwd)/install` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0")*
- `cmake -S . -B build-qt5 -GNinja -DQT_VERSION_MAJOR=5 -DCMAKE_INSTALL_PREFIX=$(pwd)/install` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0")*


------
https://chatgpt.com/codex/tasks/task_e_68ba0f9059ac8329aa7934d33125adc8