### PR TITLE
Add optional Qt5 build support and document build flag

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -15,10 +15,12 @@ apt install git cmake make g++ extra-cmake-modules qt6-base-dev qt6-declarative-
    Optional components:
    - `kf6-dbusaddons-dev` and `kf6-globalaccel-dev` (requires Qt's DBus module, provided by `qt6-base-dev`)
    - `kf6-doctools-dev` to build documentation
+   To build with Qt5/KF5, install the corresponding Qt5 and KF5 development packages and see the configure step below.
 2. Clone with `git clone https://invent.kde.org/utilities/konsole.git`
 3. Make _build_ directory: `mkdir konsole/build`
 4. Change into _build_ directory: `cd konsole/build`
 5. Configure: `cmake ..` (or `cmake .. -DCMAKE_INSTALL_PREFIX=/where/your/want/to/install`)
+   To build against Qt5/KF5 use: `cmake .. -DBUILD_WITH_QT5=ON`
 6. Build: `make`
 7. Install: `make install`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,26 @@ set(RELEASE_SERVICE_VERSION "${RELEASE_SERVICE_VERSION_MAJOR}.${RELEASE_SERVICE_
 # See comments in https://invent.kde.org/utilities/konsole/-/commit/9d8e47298c81fc1e47c998eda1b6e980589274eb
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-set(QT_MIN_VERSION "6.4.2")
-set(KF6_DEP_VERSION "6.0.0")
+option(BUILD_WITH_QT5 "Build against Qt5/KF5 instead of Qt6/KF6" OFF)
+
+if(BUILD_WITH_QT5)
+    set(QT_MAJOR_VERSION 5)
+    set(QT_MIN_VERSION "5.15.2")
+    set(KF_MAJOR_VERSION 5)
+    set(KF_MIN_VERSION "5.105.0")
+else()
+    set(QT_MAJOR_VERSION 6)
+    set(QT_MIN_VERSION "6.4.2")
+    set(KF_MAJOR_VERSION 6)
+    set(KF_MIN_VERSION "6.0.0")
+endif()
+
+set(KF_PREFIX KF${KF_MAJOR_VERSION})
 
 # Release script will create bugzilla versions
-project(konsole VERSION ${RELEASE_SERVICE_VERSION})
+project(konsole VERSION ${RELEASE_SERVICE_VERSION} LANGUAGES CXX)
 
-find_package(ECM ${KF6_DEP_VERSION} REQUIRED NO_MODULE)
+find_package(ECM ${KF_MIN_VERSION} REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH})
 
 include(KDEInstallDirs)
@@ -41,14 +54,14 @@ include(CheckIncludeFiles)
 # Allows passing e.g. -DECM_ENABLE_SANITIZERS='address;undefined' to cmake.
 include(ECMEnableSanitizers)
 
-find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED
+find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
     Core
     Multimedia
     PrintSupport
     Widgets
 )
 
-find_package(KF6 ${KF6_DEP_VERSION} REQUIRED
+find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
     Bookmarks
     Config
     ConfigWidgets
@@ -71,7 +84,7 @@ find_package(KF6 ${KF6_DEP_VERSION} REQUIRED
 )
 
 if(NOT WIN32)
-    find_package(KF6 ${KF6_DEP_VERSION} REQUIRED
+    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
         Pty
     )
 endif()
@@ -84,18 +97,19 @@ if(UNIX AND NOT APPLE AND NOT ANDROID AND NOT HAIKU)
 endif()
 option(USE_DBUS "Build components using DBus" ${USE_DBUS_DEFAULT})
 if(USE_DBUS)
-    find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED
+    find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
         DBus
     )
-    find_package(KF6 ${KF6_DEP_VERSION} REQUIRED
+    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
         DBusAddons
         GlobalAccel
     )
     set(HAVE_DBUS 1)
 endif()
 
-find_package(KF6DocTools ${KF6_DEP_VERSION})
-set_package_properties(KF6DocTools PROPERTIES DESCRIPTION
+set(KFDocTools_MODULE KF${KF_MAJOR_VERSION}DocTools)
+find_package(${KFDocTools_MODULE} ${KF_MIN_VERSION})
+set_package_properties(${KFDocTools_MODULE} PROPERTIES DESCRIPTION
     "Tools to generate documentation"
     TYPE OPTIONAL
 )
@@ -132,7 +146,7 @@ option(ENABLE_PLUGIN_QUICKCOMMANDS "Build the Quick Commands plugin" ON)
 add_subdirectory( src )
 add_subdirectory( desktop )
 
-if(KF6DocTools_FOUND)
+if(${KFDocTools_MODULE}_FOUND)
     add_subdirectory( doc/manual )
 endif()
 
@@ -152,7 +166,7 @@ ecm_qt_install_logging_categories(
 )
 
 ki18n_install( po )
-if(KF6DocTools_FOUND)
+if(${KFDocTools_MODULE}_FOUND)
     kdoctools_install( po )
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,18 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-		"CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
+            "name": "dev-qt5",
+            "displayName": "Build as debug using Qt5",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build-qt5",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "BUILD_WITH_QT5": "ON"
             }
         },
         {
@@ -81,6 +92,10 @@
         {
             "name": "dev",
             "configurePreset": "dev"
+        },
+        {
+            "name": "dev-qt5",
+            "configurePreset": "dev-qt5"
         },
         {
             "name": "asan",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file(config-konsole.h.cmake
 
 ### Tests
 if(BUILD_TESTING)
-        find_package(Qt6Test ${QT_MIN_VERSION} CONFIG REQUIRED)
+        find_package(Qt${QT_MAJOR_VERSION}Test ${QT_MIN_VERSION} CONFIG REQUIRED)
         add_subdirectory(autotests)
         add_subdirectory(tests)
 endif()
@@ -64,32 +64,32 @@ if(HAVE_DBUS)
 endif()
 
 set(konsole_LIBS
-    KF6::XmlGui
+    ${KF_PREFIX}::XmlGui
     Qt::Multimedia
     Qt::PrintSupport
     Qt::Xml
-    KF6::Notifications
-    KF6::WindowSystem
-    KF6::TextWidgets
-    KF6::GuiAddons
-    KF6::IconThemes
-    KF6::KCMUtils
-    KF6::Bookmarks
-    KF6::I18n
-    KF6::KIOWidgets
-    KF6::NewStuffCore
+    ${KF_PREFIX}::Notifications
+    ${KF_PREFIX}::WindowSystem
+    ${KF_PREFIX}::TextWidgets
+    ${KF_PREFIX}::GuiAddons
+    ${KF_PREFIX}::IconThemes
+    ${KF_PREFIX}::KCMUtils
+    ${KF_PREFIX}::Bookmarks
+    ${KF_PREFIX}::I18n
+    ${KF_PREFIX}::KIOWidgets
+    ${KF_PREFIX}::NewStuffCore
 )
 
 if(NOT WIN32)
     list(APPEND konsole_LIBS
-        KF6::Pty
+        ${KF_PREFIX}::Pty
     )
 endif()
 
 if(HAVE_DBUS)
     list(APPEND konsole_LIBS
-        KF6::DBusAddons
-        KF6::GlobalAccel
+        ${KF_PREFIX}::DBusAddons
+        ${KF_PREFIX}::GlobalAccel
     )
 endif()
 
@@ -121,7 +121,7 @@ ecm_qt_declare_logging_category(
 add_library(konsoleprivate_core STATIC ${konsoleprivate_core_SRCS})
 # Needed to link this static lib to shared libs
 set_target_properties(konsoleprivate_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(konsoleprivate_core KF6::CoreAddons)
+target_link_libraries(konsoleprivate_core ${KF_PREFIX}::CoreAddons)
 
 set(konsolehelpers_SRCS
     LabelsAligner.cpp
@@ -293,8 +293,8 @@ target_link_libraries(konsoleprivate
     konsolehelpers
     konsolecharacters
     konsoledecoders
-    KF6::NewStuffCore
-    KF6::NewStuffWidgets
+    ${KF_PREFIX}::NewStuffCore
+    ${KF_PREFIX}::NewStuffWidgets
     ${konsole_LIBS}
     ZLIB::ZLIB
     ICU::uc
@@ -303,8 +303,8 @@ target_link_libraries(konsoleprivate
 
 target_link_libraries(konsoleprivate
     PRIVATE
-    KF6::IconWidgets
-    KF6::BookmarksWidgets
+    ${KF_PREFIX}::IconWidgets
+    ${KF_PREFIX}::BookmarksWidgets
 )
 
 set_target_properties(konsoleprivate PROPERTIES
@@ -335,14 +335,14 @@ target_compile_definitions(konsoleapp PRIVATE -DRELEASE_SERVICE_VERSION="${RELEA
 
 target_link_libraries(konsoleapp
   konsoleprivate
-  KF6::XmlGui
-  KF6::WindowSystem
-  KF6::Bookmarks
-  KF6::I18n
-  KF6::KIOWidgets
-  KF6::NotifyConfig
-  KF6::Crash
-  KF6::ConfigWidgets
+  ${KF_PREFIX}::XmlGui
+  ${KF_PREFIX}::WindowSystem
+  ${KF_PREFIX}::Bookmarks
+  ${KF_PREFIX}::I18n
+  ${KF_PREFIX}::KIOWidgets
+  ${KF_PREFIX}::NotifyConfig
+  ${KF_PREFIX}::Crash
+  ${KF_PREFIX}::ConfigWidgets
 )
 
 set_target_properties(konsoleapp PROPERTIES
@@ -362,13 +362,13 @@ add_executable(konsole ${konsole_SRCS} ${ICONS_SOURCES})
 target_link_libraries(konsole
   konsoleprivate
   konsoleapp
-  KF6::XmlGui
-  KF6::WindowSystem
-  KF6::Bookmarks
-  KF6::I18n
-  KF6::KIOWidgets
-  KF6::NotifyConfig
-  KF6::Crash
+  ${KF_PREFIX}::XmlGui
+  ${KF_PREFIX}::WindowSystem
+  ${KF_PREFIX}::Bookmarks
+  ${KF_PREFIX}::I18n
+  ${KF_PREFIX}::KIOWidgets
+  ${KF_PREFIX}::NotifyConfig
+  ${KF_PREFIX}::Crash
 )
 
 if(APPLE)
@@ -397,8 +397,8 @@ add_library(konsolepart MODULE ${konsolepart_PART_SRCS})
 generate_export_header(konsolepart BASE_NAME konsole)
 set_target_properties(konsolepart PROPERTIES DEFINE_SYMBOL KONSOLE_PART)
 target_link_libraries(konsolepart
-    KF6::Parts
-    KF6::XmlGui
+    ${KF_PREFIX}::Parts
+    ${KF_PREFIX}::XmlGui
     konsoleprivate
 )
 

--- a/src/autotests/CMakeLists.txt
+++ b/src/autotests/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT WIN32)
     ecm_add_test(
         PartTest.cpp
-        LINK_LIBRARIES KF6::XmlGui KF6::Parts KF6::Pty ${KONSOLE_TEST_LIBS}
+        LINK_LIBRARIES ${KF_PREFIX}::XmlGui ${KF_PREFIX}::Parts ${KF_PREFIX}::Pty ${KONSOLE_TEST_LIBS}
     )
 endif()
 
@@ -38,7 +38,7 @@ ecm_add_tests(
 if(NOT WIN32)
     ecm_add_tests(
         PtyTest.cpp
-        LINK_LIBRARIES KF6::Pty ${KONSOLE_TEST_LIBS}
+        LINK_LIBRARIES ${KF_PREFIX}::Pty ${KONSOLE_TEST_LIBS}
     )
 endif()
 
@@ -48,5 +48,5 @@ ecm_add_tests(
     TerminalInterfaceTest.cpp
     TerminalTest.cpp
     ViewManagerTest.cpp
-    LINK_LIBRARIES ${KONSOLE_TEST_LIBS} KF6::Parts
+    LINK_LIBRARIES ${KONSOLE_TEST_LIBS} ${KF_PREFIX}::Parts
 )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -8,5 +8,5 @@ set(KONSOLE_TEST_LIBS Qt::Test konsoleprivate)
 
 add_executable(PartManualTest PartManualTest.cpp)
 ecm_mark_as_test(PartManualTest)
-target_link_libraries(PartManualTest KF6::XmlGui KF6::Parts ${KONSOLE_TEST_LIBS})
+target_link_libraries(PartManualTest ${KF_PREFIX}::XmlGui ${KF_PREFIX}::Parts ${KONSOLE_TEST_LIBS})
 

--- a/src/tests/demo_konsolepart/CMakeLists.txt
+++ b/src/tests/demo_konsolepart/CMakeLists.txt
@@ -12,11 +12,10 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 include(ECMInstallIcons)
 include(FeatureSummary)
 
-set(QT_MIN_VERSION "6.4.2")
-find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets)
+# Use the same minimum versions as the main project
+find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets)
 
-set(REQUIRED_KF_VERSION "6.0.0")
-find_package(KF6 ${REQUIRED_KF_VERSION} REQUIRED COMPONENTS
+find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED COMPONENTS
     CoreAddons
     I18n
 )

--- a/src/tests/demo_konsolepart/src/CMakeLists.txt
+++ b/src/tests/demo_konsolepart/src/CMakeLists.txt
@@ -6,11 +6,11 @@ set(demo_konsolepart_SRCS
 add_executable(demo_konsolepart ${demo_konsolepart_SRCS})
 
 target_link_libraries(demo_konsolepart
-    KF6::CoreAddons
-    KF6::I18n
-    KF6::Parts
-    KF6::Service
+    ${KF_PREFIX}::CoreAddons
+    ${KF_PREFIX}::I18n
+    ${KF_PREFIX}::Parts
+    ${KF_PREFIX}::Service
     Qt::Widgets
-    KF6::XmlGui
-    KF6::WindowSystem
+    ${KF_PREFIX}::XmlGui
+    ${KF_PREFIX}::WindowSystem
 )

--- a/tools/uni2characterwidth/CMakeLists.txt
+++ b/tools/uni2characterwidth/CMakeLists.txt
@@ -11,10 +11,10 @@ if(KONSOLE_BUILD_UNI2CHARACTERWIDTH)
 #       some other errors that will need fixed.  For now if this
 #       needs to be used, build it on a Qt5 system.
 
-    find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED
+    find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
         Core
     )
-    find_package(KF6 ${KF_MIN_VERSION} REQUIRED
+    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
         KIO
     )
 
@@ -28,7 +28,7 @@ if(KONSOLE_BUILD_UNI2CHARACTERWIDTH)
     add_executable(uni2characterwidth ${uni2characterwidth_SRC})
     target_link_libraries(uni2characterwidth
         Qt::Core
-        KF6::KIOCore
+        ${KF_PREFIX}::KIOCore
     )
 
 endif()


### PR DESCRIPTION
## Summary
- add `BUILD_WITH_QT5` option and handle Qt/KF versions dynamically
- update build presets and docs to illustrate Qt5 builds
- generalize CMake files to use the chosen Qt/KF major version

## Testing
- `cmake -S . -B build -DBUILD_WITH_QT5=ON` *(fails: Could not find a package configuration file provided by "ECM" (requested version 5.105.0))*
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ECM" (requested version 6.0.0))*


------
https://chatgpt.com/codex/tasks/task_e_68ba0fd375748329a8ac59d3283c7b4d