### PR TITLE
Fix truncated CMakeLists causing cmake parse error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,4 +135,54 @@ add_definitions(
   -DQT_NO_URL_CAST_FROM_STRING
 )
 
-set(CMAKE
+# C++ standard configuration
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+
+file(GLOB ICONS_SRCS "data/icons/*.png")
+
+option(ENABLE_PLUGIN_SSHMANAGER "Build the SSHManager plugin" ON)
+option(ENABLE_PLUGIN_QUICKCOMMANDS "Build the Quick Commands plugin" ON)
+
+add_subdirectory( src )
+add_subdirectory( desktop )
+
+if(${KFDocTools_MODULE}_FOUND)
+    add_subdirectory( doc/manual )
+endif()
+
+add_subdirectory( tools )
+
+# Conditionally install icons for Linux as they may not be provided by the user theme
+option(INSTALL_ICONS "Install icons" OFF)
+if(INSTALL_ICONS)
+    include(ECMInstallIcons)
+    ecm_install_icons( ICONS ${ICONS_SRCS} DESTINATION ${KDE_INSTALL_ICONDIR} )
+endif()
+
+ecm_qt_install_logging_categories(
+    EXPORT KONSOLE
+    FILE konsole.categories
+    DESTINATION "${KDE_INSTALL_LOGGINGCATEGORIESDIR}"
+)
+
+ki18n_install( po )
+if(${KFDocTools_MODULE}_FOUND)
+    kdoctools_install( po )
+endif()
+
+if(ECM_VERSION VERSION_GREATER_EQUAL 5.101.0)
+  install(FILES completions/konsole.zsh RENAME _konsole DESTINATION ${KDE_INSTALL_ZSHAUTOCOMPLETEDIR})
+endif()
+
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+# add clang-format target for all our real source files
+file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES *.c *.cpp *.h *.hpp)
+kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})
+if(ECM_VERSION VERSION_GREATER_EQUAL 5.79.0)
+    kde_configure_git_pre_commit_hook(CHECKS CLANG_FORMAT)
+endif()


### PR DESCRIPTION
## Summary
- Restore lost C++ standard and build configuration in CMakeLists.txt
- Re-enable plugin, documentation, and icon installation setup

## Testing
- `cmake -S . -B build` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0". The following configuration files were considered but not accepted: /usr/share/ECM/cmake/ECMConfig.cmake, version: 5.115.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb213460f48329bd0c6e0318abb1f2