### PR TITLE
Fix plugin version parsing

### DIFF
--- a/src/pluginsystem/PluginManager.cpp
+++ b/src/pluginsystem/PluginManager.cpp
@@ -35,7 +35,7 @@ PluginManager::~PluginManager() = default;
 void PluginManager::loadAllPlugins() {
   auto filter = [](const KPluginMetaData &data) {
     const QVersionNumber pluginVersion =
-        QVersionNumber::fromString(QString::fromLatin1(data.version()));
+        QVersionNumber::fromString(data.version());
 
     const QVersionNumber releaseVersion =
         QVersionNumber::fromString(QLatin1String(RELEASE_SERVICE_VERSION));


### PR DESCRIPTION
## Summary
- fix plugin version parsing by dropping incorrect Latin1 conversion

## Testing
- `cmake -S . -B build` *(fails: Could not find a configuration file for package "ECM" that is compatible with requested version "6.0.0"; version 5.115.0 is installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb23af73908329835857d5cbecfe42