### PR TITLE
Remove Qt5 compatibility code and references

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -15,16 +15,14 @@ apt install git cmake make g++ extra-cmake-modules qt6-base-dev qt6-declarative-
    Optional components:
    - `kf6-dbusaddons-dev` and `kf6-globalaccel-dev` (requires Qt's DBus module, provided by `qt6-base-dev`)
    - `kf6-doctools-dev` to build documentation
-   To build with Qt5/KF5, install the corresponding Qt5 and KF5 development packages and see the configure step below.
 2. Clone with `git clone https://invent.kde.org/utilities/konsole.git`
 3. Make _build_ directory: `mkdir konsole/build`
 4. Change into _build_ directory: `cd konsole/build`
 5. Configure: `cmake ..` (or `cmake .. -DCMAKE_INSTALL_PREFIX=/where/your/want/to/install`)
-   To build against Qt5/KF5 use: `cmake .. -DBUILD_WITH_QT5=ON`
 
    Alternatively, from the project root you can run:
    ```
-   cmake -S . -B build -DBUILD_WITH_QT5=ON
+   cmake -S . -B build
    ```
 6. Build: `make`
 7. Install: `make install`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,26 +10,11 @@ set(RELEASE_SERVICE_VERSION "${RELEASE_SERVICE_VERSION_MAJOR}.${RELEASE_SERVICE_
 # approval from maintainer(s).
 # minimal requirements
 
-# See comments in https://invent.kde.org/utilities/konsole/-/commit/9d8e47298c81fc1e47c998eda1b6e980589274eb
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-option(BUILD_WITH_QT5 "Build against Qt5/KF5 instead of Qt6/KF6" OFF)
-
-if(BUILD_WITH_QT5)
-    set(QT_MAJOR_VERSION 5)
-    set(QT_MIN_VERSION "5.15.2")
-    set(KF_MAJOR_VERSION 5)
-    set(KF_MIN_VERSION "5.105.0")
-    set(ECM_MIN_VERSION "5.105.0")
-else()
-    set(QT_MAJOR_VERSION 6)
-    set(QT_MIN_VERSION "6.4.2")
-    set(KF_MAJOR_VERSION 6)
-    set(KF_MIN_VERSION "6.0.0")
-    set(ECM_MIN_VERSION "6.0.0")
-endif()
-
-set(KF_PREFIX KF${KF_MAJOR_VERSION})
+set(QT_MIN_VERSION "6.4.2")
+set(KF_MIN_VERSION "6.0.0")
+set(ECM_MIN_VERSION "6.0.0")
 
 # Release script will create bugzilla versions
 project(konsole VERSION ${RELEASE_SERVICE_VERSION} LANGUAGES CXX)
@@ -57,14 +42,14 @@ include(CheckIncludeFiles)
 # Allows passing e.g. -DECM_ENABLE_SANITIZERS='address;undefined' to cmake.
 include(ECMEnableSanitizers)
 
-find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED
     Core
     Multimedia
     PrintSupport
     Widgets
 )
 
-find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+find_package(KF6 ${KF_MIN_VERSION} REQUIRED
     Bookmarks
     Config
     ConfigWidgets
@@ -87,7 +72,7 @@ find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
 )
 
 if(NOT WIN32)
-    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+    find_package(KF6 ${KF_MIN_VERSION} REQUIRED
         Pty
     )
 endif()
@@ -100,17 +85,17 @@ if(UNIX AND NOT APPLE AND NOT ANDROID AND NOT HAIKU)
 endif()
 option(USE_DBUS "Build components using DBus" ${USE_DBUS_DEFAULT})
 if(USE_DBUS)
-    find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
+    find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED
         DBus
     )
-    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+    find_package(KF6 ${KF_MIN_VERSION} REQUIRED
         DBusAddons
         GlobalAccel
     )
     set(HAVE_DBUS 1)
 endif()
 
-set(KFDocTools_MODULE KF${KF_MAJOR_VERSION}DocTools)
+set(KFDocTools_MODULE KF6DocTools)
 find_package(${KFDocTools_MODULE} ${KF_MIN_VERSION})
 set_package_properties(${KFDocTools_MODULE} PROPERTIES DESCRIPTION
     "Tools to generate documentation"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,17 +12,6 @@
             }
         },
         {
-            "name": "dev-qt5",
-            "displayName": "Build as debug using Qt5",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build-qt5",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-                "BUILD_WITH_QT5": "ON"
-            }
-        },
-        {
             "name": "dev-disable-deprecated",
             "displayName": "Build as without deprecated methods",
             "generator": "Ninja",
@@ -92,10 +81,6 @@
         {
             "name": "dev",
             "configurePreset": "dev"
-        },
-        {
-            "name": "dev-qt5",
-            "configurePreset": "dev-qt5"
         },
         {
             "name": "asan",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file(config-konsole.h.cmake
 
 ### Tests
 if(BUILD_TESTING)
-        find_package(Qt${QT_MAJOR_VERSION}Test ${QT_MIN_VERSION} CONFIG REQUIRED)
+        find_package(Qt6Test ${QT_MIN_VERSION} CONFIG REQUIRED)
         add_subdirectory(autotests)
         add_subdirectory(tests)
 endif()
@@ -64,32 +64,32 @@ if(HAVE_DBUS)
 endif()
 
 set(konsole_LIBS
-    ${KF_PREFIX}::XmlGui
+    KF6::XmlGui
     Qt::Multimedia
     Qt::PrintSupport
     Qt::Xml
-    ${KF_PREFIX}::Notifications
-    ${KF_PREFIX}::WindowSystem
-    ${KF_PREFIX}::TextWidgets
-    ${KF_PREFIX}::GuiAddons
-    ${KF_PREFIX}::IconThemes
-    ${KF_PREFIX}::KCMUtils
-    ${KF_PREFIX}::Bookmarks
-    ${KF_PREFIX}::I18n
-    ${KF_PREFIX}::KIOWidgets
-    ${KF_PREFIX}::NewStuffCore
+    KF6::Notifications
+    KF6::WindowSystem
+    KF6::TextWidgets
+    KF6::GuiAddons
+    KF6::IconThemes
+    KF6::KCMUtils
+    KF6::Bookmarks
+    KF6::I18n
+    KF6::KIOWidgets
+    KF6::NewStuffCore
 )
 
 if(NOT WIN32)
     list(APPEND konsole_LIBS
-        ${KF_PREFIX}::Pty
+        KF6::Pty
     )
 endif()
 
 if(HAVE_DBUS)
     list(APPEND konsole_LIBS
-        ${KF_PREFIX}::DBusAddons
-        ${KF_PREFIX}::GlobalAccel
+        KF6::DBusAddons
+        KF6::GlobalAccel
     )
 endif()
 
@@ -121,7 +121,7 @@ ecm_qt_declare_logging_category(
 add_library(konsoleprivate_core STATIC ${konsoleprivate_core_SRCS})
 # Needed to link this static lib to shared libs
 set_target_properties(konsoleprivate_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(konsoleprivate_core ${KF_PREFIX}::CoreAddons)
+target_link_libraries(konsoleprivate_core KF6::CoreAddons)
 
 set(konsolehelpers_SRCS
     LabelsAligner.cpp
@@ -293,8 +293,8 @@ target_link_libraries(konsoleprivate
     konsolehelpers
     konsolecharacters
     konsoledecoders
-    ${KF_PREFIX}::NewStuffCore
-    ${KF_PREFIX}::NewStuffWidgets
+    KF6::NewStuffCore
+    KF6::NewStuffWidgets
     ${konsole_LIBS}
     ZLIB::ZLIB
     ICU::uc
@@ -303,8 +303,8 @@ target_link_libraries(konsoleprivate
 
 target_link_libraries(konsoleprivate
     PRIVATE
-    ${KF_PREFIX}::IconWidgets
-    ${KF_PREFIX}::BookmarksWidgets
+    KF6::IconWidgets
+    KF6::BookmarksWidgets
 )
 
 set_target_properties(konsoleprivate PROPERTIES
@@ -335,14 +335,14 @@ target_compile_definitions(konsoleapp PRIVATE -DRELEASE_SERVICE_VERSION="${RELEA
 
 target_link_libraries(konsoleapp
   konsoleprivate
-  ${KF_PREFIX}::XmlGui
-  ${KF_PREFIX}::WindowSystem
-  ${KF_PREFIX}::Bookmarks
-  ${KF_PREFIX}::I18n
-  ${KF_PREFIX}::KIOWidgets
-  ${KF_PREFIX}::NotifyConfig
-  ${KF_PREFIX}::Crash
-  ${KF_PREFIX}::ConfigWidgets
+  KF6::XmlGui
+  KF6::WindowSystem
+  KF6::Bookmarks
+  KF6::I18n
+  KF6::KIOWidgets
+  KF6::NotifyConfig
+  KF6::Crash
+  KF6::ConfigWidgets
 )
 
 set_target_properties(konsoleapp PROPERTIES
@@ -362,13 +362,13 @@ add_executable(konsole ${konsole_SRCS} ${ICONS_SOURCES})
 target_link_libraries(konsole
   konsoleprivate
   konsoleapp
-  ${KF_PREFIX}::XmlGui
-  ${KF_PREFIX}::WindowSystem
-  ${KF_PREFIX}::Bookmarks
-  ${KF_PREFIX}::I18n
-  ${KF_PREFIX}::KIOWidgets
-  ${KF_PREFIX}::NotifyConfig
-  ${KF_PREFIX}::Crash
+  KF6::XmlGui
+  KF6::WindowSystem
+  KF6::Bookmarks
+  KF6::I18n
+  KF6::KIOWidgets
+  KF6::NotifyConfig
+  KF6::Crash
 )
 
 if(APPLE)
@@ -397,8 +397,8 @@ add_library(konsolepart MODULE ${konsolepart_PART_SRCS})
 generate_export_header(konsolepart BASE_NAME konsole)
 set_target_properties(konsolepart PROPERTIES DEFINE_SYMBOL KONSOLE_PART)
 target_link_libraries(konsolepart
-    ${KF_PREFIX}::Parts
-    ${KF_PREFIX}::XmlGui
+    KF6::Parts
+    KF6::XmlGui
     konsoleprivate
 )
 

--- a/src/ScrollState.h
+++ b/src/ScrollState.h
@@ -17,9 +17,8 @@ namespace Konsole
  * Modern high precision scroll events supply many smaller events
  * that may or may not translate into a UI action to support smooth
  * pixel level scrolling. Builtin classes such as QScrollBar
- * support these events under Qt5, but custom code
- * written to handle scroll events in other ways must be modified
- * to accumulate small deltas and act when suitable thresholds have
+ * support these events, but custom code written to handle scroll events
+ * must be modified to accumulate small deltas and act when suitable thresholds have
  * been reached (ideally 1 for pixel scroll values towards any action
  * that can be mapped to a pixel movement).
  */

--- a/src/autotests/CMakeLists.txt
+++ b/src/autotests/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT WIN32)
     ecm_add_test(
         PartTest.cpp
-        LINK_LIBRARIES ${KF_PREFIX}::XmlGui ${KF_PREFIX}::Parts ${KF_PREFIX}::Pty ${KONSOLE_TEST_LIBS}
+        LINK_LIBRARIES KF6::XmlGui KF6::Parts KF6::Pty ${KONSOLE_TEST_LIBS}
     )
 endif()
 
@@ -38,7 +38,7 @@ ecm_add_tests(
 if(NOT WIN32)
     ecm_add_tests(
         PtyTest.cpp
-        LINK_LIBRARIES ${KF_PREFIX}::Pty ${KONSOLE_TEST_LIBS}
+        LINK_LIBRARIES KF6::Pty ${KONSOLE_TEST_LIBS}
     )
 endif()
 
@@ -48,5 +48,5 @@ ecm_add_tests(
     TerminalInterfaceTest.cpp
     TerminalTest.cpp
     ViewManagerTest.cpp
-    LINK_LIBRARIES ${KONSOLE_TEST_LIBS} ${KF_PREFIX}::Parts
+    LINK_LIBRARIES ${KONSOLE_TEST_LIBS} KF6::Parts
 )

--- a/src/plugins/QuickCommands/CMakeLists.txt
+++ b/src/plugins/QuickCommands/CMakeLists.txt
@@ -9,7 +9,7 @@ SOURCES
     filtermodel.cpp
     ${EXTRA_QUICKCOMMANDSPLUGIN_SRCS}
 INSTALL_NAMESPACE
-    "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
+    "qt6/plugins/konsoleplugins"
 )
 
 configure_file(konsole_quickcommands.in.json konsole_quickcommands.json)

--- a/src/plugins/RandomColors/CMakeLists.txt
+++ b/src/plugins/RandomColors/CMakeLists.txt
@@ -2,7 +2,7 @@ kcoreaddons_add_plugin(konsole_randomcolorsplugin
     SOURCES
         randomcolorsplugin.cpp
     INSTALL_NAMESPACE
-        "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
+        "qt6/plugins/konsoleplugins"
 )
 
 configure_file(konsole_randomcolors.in.json konsole_randomcolors.json)

--- a/src/plugins/SSHManager/CMakeLists.txt
+++ b/src/plugins/SSHManager/CMakeLists.txt
@@ -20,7 +20,7 @@ SOURCES
     sshtreeview.cpp
     ${extra_sshplugin_SRCS}
 INSTALL_NAMESPACE
-    "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
+    "qt6/plugins/konsoleplugins"
 )
 
 configure_file(konsole_sshmanager.in.json konsole_sshmanager.json)

--- a/src/pluginsystem/PluginManager.cpp
+++ b/src/pluginsystem/PluginManager.cpp
@@ -54,16 +54,11 @@ void PluginManager::loadAllPlugins() {
   };
 
   QString pluginNamespace = QStringLiteral("konsoleplugins");
-#if QT_VERSION_MAJOR >= 6
   QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(
       QStringLiteral("kf6/konsoleplugins"), filter);
   if (pluginMetaData.isEmpty()) {
     pluginMetaData = KPluginMetaData::findPlugins(pluginNamespace, filter);
   }
-#else
-  QVector<KPluginMetaData> pluginMetaData =
-      KPluginMetaData::findPlugins(pluginNamespace, filter);
-#endif
 
   const QStringList extraPaths = KonsoleSettings::customPluginPaths();
   for (const QString &path : extraPaths) {

--- a/src/session/SessionController.cpp
+++ b/src/session/SessionController.cpp
@@ -1413,7 +1413,6 @@ void SessionController::copyInputToNone()
         return;
     }
 
-    // Once Qt5.14+ is the minimum, change to use range constructors
     const QList<Session *> groupList = SessionManager::instance()->sessions();
     QSet<Session *> group(groupList.begin(), groupList.end());
 

--- a/src/terminalDisplay/TerminalPainter.cpp
+++ b/src/terminalDisplay/TerminalPainter.cpp
@@ -648,10 +648,8 @@ void TerminalPainter::drawCharacters(QPainter &painter,
         QFont::Black,
     };
 
-    // The weight used as bold depends on selected font's weight.
+    // The weight used as bold depends on the selected font's weight.
     // "Regular" will use "Bold", but e.g. "Thin" will use "Light".
-    // Note that QFont::weight/setWeight() returns/takes an int in Qt5,
-    // and a QFont::Weight in Qt6
     const auto normalWeight = m_parentDisplay->font().weight();
     auto it = std::upper_bound(std::begin(FontWeights), std::end(FontWeights), normalWeight);
     const QFont::Weight boldWeight = it != std::end(FontWeights) ? *it : QFont::Black;
@@ -1109,10 +1107,8 @@ void TerminalPainter::drawTextCharacters(QPainter &painter,
         characterColor = QColor(0, 0, 0);
     }
 
-    // The weight used as bold depends on selected font's weight.
+    // The weight used as bold depends on the selected font's weight.
     // "Regular" will use "Bold", but e.g. "Thin" will use "Light".
-    // Note that QFont::weight/setWeight() returns/takes an int in Qt5,
-    // and a QFont::Weight in Qt6
     QFont savedFont;
     bool restoreFont = false;
     if ((style.flags & EF_EMOJI_REPRESENTATION) && m_parentDisplay->terminalFont()->hasExtraFont(0)) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -8,5 +8,5 @@ set(KONSOLE_TEST_LIBS Qt::Test konsoleprivate)
 
 add_executable(PartManualTest PartManualTest.cpp)
 ecm_mark_as_test(PartManualTest)
-target_link_libraries(PartManualTest ${KF_PREFIX}::XmlGui ${KF_PREFIX}::Parts ${KONSOLE_TEST_LIBS})
+target_link_libraries(PartManualTest KF6::XmlGui KF6::Parts ${KONSOLE_TEST_LIBS})
 

--- a/src/tests/demo_konsolepart/CMakeLists.txt
+++ b/src/tests/demo_konsolepart/CMakeLists.txt
@@ -13,9 +13,9 @@ include(ECMInstallIcons)
 include(FeatureSummary)
 
 # Use the same minimum versions as the main project
-find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets)
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets)
 
-find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED COMPONENTS
+find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS
     CoreAddons
     I18n
 )

--- a/src/tests/demo_konsolepart/src/CMakeLists.txt
+++ b/src/tests/demo_konsolepart/src/CMakeLists.txt
@@ -6,11 +6,11 @@ set(demo_konsolepart_SRCS
 add_executable(demo_konsolepart ${demo_konsolepart_SRCS})
 
 target_link_libraries(demo_konsolepart
-    ${KF_PREFIX}::CoreAddons
-    ${KF_PREFIX}::I18n
-    ${KF_PREFIX}::Parts
-    ${KF_PREFIX}::Service
+    KF6::CoreAddons
+    KF6::I18n
+    KF6::Parts
+    KF6::Service
     Qt::Widgets
-    ${KF_PREFIX}::XmlGui
-    ${KF_PREFIX}::WindowSystem
+    KF6::XmlGui
+    KF6::WindowSystem
 )

--- a/tools/uni2characterwidth/CMakeLists.txt
+++ b/tools/uni2characterwidth/CMakeLists.txt
@@ -7,14 +7,12 @@
 ###   See `uni2characterwidth --help` for usage information
 if(KONSOLE_BUILD_UNI2CHARACTERWIDTH)
 
-# NOTE: this doesn't build with Qt6 even using compat and there are
-#       some other errors that will need fixed.  For now if this
-#       needs to be used, build it on a Qt5 system.
+# NOTE: this tool currently doesn't build with Qt6 and needs fixes.
 
-    find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
+    find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED
         Core
     )
-    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+    find_package(KF6 ${KF_MIN_VERSION} REQUIRED
         KIO
     )
 
@@ -28,7 +26,7 @@ if(KONSOLE_BUILD_UNI2CHARACTERWIDTH)
     add_executable(uni2characterwidth ${uni2characterwidth_SRC})
     target_link_libraries(uni2characterwidth
         Qt::Core
-        ${KF_PREFIX}::KIOCore
+        KF6::KIOCore
     )
 
 endif()


### PR DESCRIPTION
## Summary
- Drop optional Qt5 build path and rely solely on Qt6/KF6
- Simplify plugin installation paths and plugin manager search for KF6
- Update documentation and presets to remove Qt5 references

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ECM")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `source build/prefix.sh` *(fails: No such file or directory)*
- `./build/bin/konsole --list-plugins` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be79145cec832983b98b84d2d59395