### PR TITLE
Switch project to Qt5/KF5

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,29 +5,31 @@ Konsole is a terminal program for KDE.
 
 ## HOWTO Build
 
-1. Install dependencies (KDE Frameworks 6.0+). On Debian/Ubuntu:
+1. Install dependencies (KDE Frameworks 5.105+). On Debian/Ubuntu:
 ```
-apt install git cmake make g++ extra-cmake-modules qt6-base-dev qt6-declarative-dev qt6-multimedia-dev qt6-printsupport-dev \
-    kf6-bookmarks-dev kf6-config-dev kf6-configwidgets-dev kf6-coreaddons-dev kf6-crash-dev kf6-guiaddons-dev kf6-i18n-dev \
-    kf6-iconthemes-dev kf6-kio-dev kf6-newstuff-dev kf6-notifications-dev kf6-notifyconfig-dev kf6-parts-dev kf6-service-dev \
-    kf6-textwidgets-dev kf6-widgetsaddons-dev kf6-windowsystem-dev kf6-xmlgui-dev kf6-pty-dev
+apt install git cmake make g++ extra-cmake-modules qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5printsupport5-dev \
+    kf5-bookmarks-dev kf5-config-dev kf5-configwidgets-dev kf5-coreaddons-dev kf5-crash-dev kf5-guiaddons-dev kf5-i18n-dev \
+    kf5-iconthemes-dev kf5-kio-dev kf5-newstuff-dev kf5-notifications-dev kf5-notifyconfig-dev kf5-parts-dev kf5-service-dev \
+    kf5-textwidgets-dev kf5-widgetsaddons-dev kf5-windowsystem-dev kf5-xmlgui-dev kf5-pty-dev
 ```
    Optional components:
-   - `kf6-dbusaddons-dev` and `kf6-globalaccel-dev` (requires Qt's DBus module, provided by `qt6-base-dev`)
-   - `kf6-doctools-dev` to build documentation
-   To build with Qt5/KF5, install the corresponding Qt5 and KF5 development packages and see the configure step below.
+   - `kf5-dbusaddons-dev` and `kf5-globalaccel-dev` (requires Qt's DBus module, provided by `qtbase5-dev`)
+   - `kf5-doctools-dev` to build documentation
 2. Clone with `git clone https://invent.kde.org/utilities/konsole.git`
 3. Make _build_ directory: `mkdir konsole/build`
 4. Change into _build_ directory: `cd konsole/build`
 5. Configure: `cmake ..` (or `cmake .. -DCMAKE_INSTALL_PREFIX=/where/your/want/to/install`)
-   To build against Qt5/KF5 use: `cmake .. -DBUILD_WITH_QT5=ON`
 
    Alternatively, from the project root you can run:
    ```
-   cmake -S . -B build -DBUILD_WITH_QT5=ON
+   cmake -S . -B build
    ```
 6. Build: `make`
 7. Install: `make install`
 
 
+### Qt5 limitations
 
+* Plugins are installed under `qt5/plugins/konsoleplugins`; existing builds for Qt6 must be relocated.
+* DBus helpers use the older `qt5_*` macros as `qt_add_dbus_adaptor` is unavailable in Qt5.
+* `KColorSchemeManager::instance()` is not present in KF5; an explicit manager object is used instead.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,23 +13,14 @@ set(RELEASE_SERVICE_VERSION "${RELEASE_SERVICE_VERSION_MAJOR}.${RELEASE_SERVICE_
 # See comments in https://invent.kde.org/utilities/konsole/-/commit/9d8e47298c81fc1e47c998eda1b6e980589274eb
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-option(BUILD_WITH_QT5 "Build against Qt5/KF5 instead of Qt6/KF6" OFF)
+# Build against Qt5 and KF5
+set(QT_MAJOR_VERSION 5)
+set(QT_MIN_VERSION "5.15.2")
+set(KF_MAJOR_VERSION 5)
+set(KF_MIN_VERSION "5.105.0")
+set(ECM_MIN_VERSION "5.105.0")
 
-if(BUILD_WITH_QT5)
-    set(QT_MAJOR_VERSION 5)
-    set(QT_MIN_VERSION "5.15.2")
-    set(KF_MAJOR_VERSION 5)
-    set(KF_MIN_VERSION "5.105.0")
-    set(ECM_MIN_VERSION "5.105.0")
-else()
-    set(QT_MAJOR_VERSION 6)
-    set(QT_MIN_VERSION "6.4.2")
-    set(KF_MAJOR_VERSION 6)
-    set(KF_MIN_VERSION "6.0.0")
-    set(ECM_MIN_VERSION "6.0.0")
-endif()
-
-set(KF_PREFIX KF${KF_MAJOR_VERSION})
+set(KF_PREFIX KF5)
 
 # Release script will create bugzilla versions
 project(konsole VERSION ${RELEASE_SERVICE_VERSION} LANGUAGES CXX)
@@ -57,14 +48,14 @@ include(CheckIncludeFiles)
 # Allows passing e.g. -DECM_ENABLE_SANITIZERS='address;undefined' to cmake.
 include(ECMEnableSanitizers)
 
-find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
+find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED
     Core
     Multimedia
     PrintSupport
     Widgets
 )
 
-find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+find_package(KF5 ${KF_MIN_VERSION} REQUIRED
     Bookmarks
     Config
     ConfigWidgets
@@ -87,7 +78,7 @@ find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
 )
 
 if(NOT WIN32)
-    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+    find_package(KF5 ${KF_MIN_VERSION} REQUIRED
         Pty
     )
 endif()
@@ -100,17 +91,17 @@ if(UNIX AND NOT APPLE AND NOT ANDROID AND NOT HAIKU)
 endif()
 option(USE_DBUS "Build components using DBus" ${USE_DBUS_DEFAULT})
 if(USE_DBUS)
-    find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
+    find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED
         DBus
     )
-    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+    find_package(KF5 ${KF_MIN_VERSION} REQUIRED
         DBusAddons
         GlobalAccel
     )
     set(HAVE_DBUS 1)
 endif()
 
-set(KFDocTools_MODULE KF${KF_MAJOR_VERSION}DocTools)
+set(KFDocTools_MODULE KF5DocTools)
 find_package(${KFDocTools_MODULE} ${KF_MIN_VERSION})
 set_package_properties(${KFDocTools_MODULE} PROPERTIES DESCRIPTION
     "Tools to generate documentation"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 Konsole-Plugin für zufällige Farbschemata beim Start neuer Terminal-Sessions.
 
-Autor: Thomas Lorkowski  
-Status: Experimentell  
-Kompatibilität: Plasma 6 / KDE Frameworks 6 / Qt 6
+Autor: Thomas Lorkowski
+Status: Experimentell
+Kompatibilität: Plasma 5 / KDE Frameworks 5 / Qt 5
 
 ───────
 
@@ -32,7 +32,7 @@ Dieses Plugin erweitert Konsole um die Fähigkeit, bei jeder neuen Terminal-Sess
   - `/usr/share/konsole/`
 
 • Installation unter:
-  - `/usr/lib/x86_64-linux-gnu/plugins/konsole/randomcolorplugin.so`
+  - `/usr/lib/x86_64-linux-gnu/qt5/plugins/konsoleplugins/konsole_randomcolorsplugin.so`
 
 • Aktivierbar über:
   - Menü → Einstellungen → Plugins

--- a/doc/manual/index.docbook
+++ b/doc/manual/index.docbook
@@ -1551,7 +1551,7 @@ For more information, please visit
 
 </variablelist>
 
-<para>&konsole; also accepts generic &Qt; and &kf6-full; options, see man pages qt6options and kf6options.</para>
+<para>&konsole; also accepts generic &Qt; and &kf5-full; options, see man pages qt5options and kf5options.</para>
 
 </chapter>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file(config-konsole.h.cmake
 
 ### Tests
 if(BUILD_TESTING)
-        find_package(Qt${QT_MAJOR_VERSION}Test ${QT_MIN_VERSION} CONFIG REQUIRED)
+        find_package(Qt5Test ${QT_MIN_VERSION} CONFIG REQUIRED)
         add_subdirectory(autotests)
         add_subdirectory(tests)
 endif()
@@ -39,18 +39,18 @@ if(HAVE_DBUS)
     # qdbuscpp2xml -M -s ViewManager.h -o org.kde.konsole.Konsole.xml
 
     # Generate dbus .xml files; do not store .xml in source folder
-    qt_generate_dbus_interface(ViewManager.h org.kde.konsole.Window.xml OPTIONS -m)
+    qt5_generate_dbus_interface(ViewManager.h org.kde.konsole.Window.xml OPTIONS -m)
 
-    qt_add_dbus_adaptor(windowadaptors_SRCS
+    qt5_add_dbus_adaptor(windowadaptors_SRCS
                         ${CMAKE_CURRENT_BINARY_DIR}/org.kde.konsole.Window.xml
                         ViewManager.h
                         Konsole::ViewManager)
 
     # qdbuscpp2xml -m  Session.h -o org.kde.konsole.Session.xml
     # Generate dbus .xml files; do not store .xml in source folder
-    qt_generate_dbus_interface(session/Session.h org.kde.konsole.Session.xml OPTIONS -m)
+    qt5_generate_dbus_interface(session/Session.h org.kde.konsole.Session.xml OPTIONS -m)
 
-    qt_add_dbus_adaptor(
+    qt5_add_dbus_adaptor(
         sessionadaptors_SRCS
         ${CMAKE_CURRENT_BINARY_DIR}/org.kde.konsole.Session.xml
         session/Session.h
@@ -65,9 +65,9 @@ endif()
 
 set(konsole_LIBS
     ${KF_PREFIX}::XmlGui
-    Qt::Multimedia
-    Qt::PrintSupport
-    Qt::Xml
+    Qt5::Multimedia
+    Qt5::PrintSupport
+    Qt5::Xml
     ${KF_PREFIX}::Notifications
     ${KF_PREFIX}::WindowSystem
     ${KF_PREFIX}::TextWidgets
@@ -132,8 +132,8 @@ add_library(konsolehelpers
 )
 set_target_properties(konsolehelpers PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(konsolehelpers
-    Qt::Core
-    Qt::Widgets
+    Qt5::Core
+    Qt5::Widgets
 )
 
 add_subdirectory(colorscheme)
@@ -402,7 +402,7 @@ target_link_libraries(konsolepart
     konsoleprivate
 )
 
-install(TARGETS konsolepart DESTINATION ${KDE_INSTALL_PLUGINDIR}/kf6/parts)
+install(TARGETS konsolepart DESTINATION ${KDE_INSTALL_PLUGINDIR}/kf5/parts)
 
 # Add cmake-options -DBUILD_COVERAGE=ON -DCOVERAGE_GENERATE_HTML=ON
 if(COVERAGE_GENERATE_HTML)

--- a/src/autotests/CMakeLists.txt
+++ b/src/autotests/CMakeLists.txt
@@ -2,7 +2,7 @@ include(ECMAddTests)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR})
 
-set(KONSOLE_TEST_LIBS Qt::Test konsoleprivate konsolecharacters konsoledecoders konsoleapp)
+set(KONSOLE_TEST_LIBS Qt5::Test konsoleprivate konsolecharacters konsoledecoders konsoleapp)
 
 if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
     set(KONSOLE_TEST_LIBS ${KONSOLE_TEST_LIBS} kvm)

--- a/src/autotests/PartTest.cpp
+++ b/src/autotests/PartTest.cpp
@@ -45,7 +45,7 @@ void PartTest::initTestCase()
 void PartTest::testFdShell()
 {
 #if defined(Q_OS_FREEBSD)
-    QSKIP("Skipping on CI FreeBSD14_qt6x", SkipSingle);
+    QSKIP("Skipping on CI FreeBSD14_qt5x", SkipSingle);
     return;
 #endif
 

--- a/src/characters/CMakeLists.txt
+++ b/src/characters/CMakeLists.txt
@@ -22,4 +22,4 @@ generate_export_header(konsolecharacters BASE_NAME konsolecharacters)
 target_include_directories(konsolecharacters
     PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
     INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(konsolecharacters Qt::Gui)
+target_link_libraries(konsolecharacters Qt5::Gui)

--- a/src/plugins/QuickCommands/CMakeLists.txt
+++ b/src/plugins/QuickCommands/CMakeLists.txt
@@ -9,7 +9,7 @@ SOURCES
     filtermodel.cpp
     ${EXTRA_QUICKCOMMANDSPLUGIN_SRCS}
 INSTALL_NAMESPACE
-    "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
+    "qt5/plugins/konsoleplugins"
 )
 
 configure_file(konsole_quickcommands.in.json konsole_quickcommands.json)

--- a/src/plugins/RandomColors/CMakeLists.txt
+++ b/src/plugins/RandomColors/CMakeLists.txt
@@ -2,7 +2,7 @@ kcoreaddons_add_plugin(konsole_randomcolorsplugin
     SOURCES
         randomcolorsplugin.cpp
     INSTALL_NAMESPACE
-        "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
+        "qt5/plugins/konsoleplugins"
 )
 
 configure_file(konsole_randomcolors.in.json konsole_randomcolors.json)

--- a/src/plugins/SSHManager/CMakeLists.txt
+++ b/src/plugins/SSHManager/CMakeLists.txt
@@ -20,7 +20,7 @@ SOURCES
     sshtreeview.cpp
     ${extra_sshplugin_SRCS}
 INSTALL_NAMESPACE
-    "qt${QT_VERSION_MAJOR}/plugins/konsoleplugins"
+    "qt5/plugins/konsoleplugins"
 )
 
 configure_file(konsole_sshmanager.in.json konsole_sshmanager.json)

--- a/src/pluginsystem/PluginManager.cpp
+++ b/src/pluginsystem/PluginManager.cpp
@@ -53,17 +53,11 @@ void PluginManager::loadAllPlugins() {
     return false;
   };
 
-  QString pluginNamespace = QStringLiteral("konsoleplugins");
-#if QT_VERSION_MAJOR >= 6
   QVector<KPluginMetaData> pluginMetaData = KPluginMetaData::findPlugins(
-      QStringLiteral("kf6/konsoleplugins"), filter);
+      QStringLiteral("qt5/plugins/konsoleplugins"), filter);
   if (pluginMetaData.isEmpty()) {
-    pluginMetaData = KPluginMetaData::findPlugins(pluginNamespace, filter);
+    pluginMetaData = KPluginMetaData::findPlugins(QStringLiteral("konsoleplugins"), filter);
   }
-#else
-  QVector<KPluginMetaData> pluginMetaData =
-      KPluginMetaData::findPlugins(pluginNamespace, filter);
-#endif
 
   const QStringList extraPaths = KonsoleSettings::customPluginPaths();
   for (const QString &path : extraPaths) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ECMMarkAsTest)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR})
 
-set(KONSOLE_TEST_LIBS Qt::Test konsoleprivate)
+set(KONSOLE_TEST_LIBS Qt5::Test konsoleprivate)
 
 add_executable(PartManualTest PartManualTest.cpp)
 ecm_mark_as_test(PartManualTest)

--- a/src/tests/demo_konsolepart/CMakeLists.txt
+++ b/src/tests/demo_konsolepart/CMakeLists.txt
@@ -13,9 +13,9 @@ include(ECMInstallIcons)
 include(FeatureSummary)
 
 # Use the same minimum versions as the main project
-find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets)
+find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets)
 
-find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED COMPONENTS
+find_package(KF5 ${KF_MIN_VERSION} REQUIRED COMPONENTS
     CoreAddons
     I18n
 )

--- a/src/tests/demo_konsolepart/src/CMakeLists.txt
+++ b/src/tests/demo_konsolepart/src/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(demo_konsolepart
     ${KF_PREFIX}::I18n
     ${KF_PREFIX}::Parts
     ${KF_PREFIX}::Service
-    Qt::Widgets
+    Qt5::Widgets
     ${KF_PREFIX}::XmlGui
     ${KF_PREFIX}::WindowSystem
 )

--- a/tools/uni2characterwidth/CMakeLists.txt
+++ b/tools/uni2characterwidth/CMakeLists.txt
@@ -11,10 +11,10 @@ if(KONSOLE_BUILD_UNI2CHARACTERWIDTH)
 #       some other errors that will need fixed.  For now if this
 #       needs to be used, build it on a Qt5 system.
 
-    find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
+    find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED
         Core
     )
-    find_package(KF${KF_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED
+    find_package(KF5 ${KF_MIN_VERSION} REQUIRED
         KIO
     )
 
@@ -27,7 +27,7 @@ if(KONSOLE_BUILD_UNI2CHARACTERWIDTH)
 
     add_executable(uni2characterwidth ${uni2characterwidth_SRC})
     target_link_libraries(uni2characterwidth
-        Qt::Core
+        Qt5::Core
         ${KF_PREFIX}::KIOCore
     )
 


### PR DESCRIPTION
## Summary
- migrate build system to Qt5 and KDE Frameworks 5
- install and load plugins from `qt5/plugins/konsoleplugins`
- document Qt5-specific limitations and update compatibility notes

## Testing
- `cmake -S . -B build` *(fails: Could NOT find KF5 (missing: Bookmarks Config ConfigWidgets CoreAddons Crash GuiAddons I18n IconThemes KCMUtils KIO NewStuff Notifications NotifyConfig Parts Service TextWidgets WidgetsAddons WindowSystem XmlGui))*

------
https://chatgpt.com/codex/tasks/task_e_68be791656448329843cfc25bd41ddb0